### PR TITLE
Tell rm not to prompt

### DIFF
--- a/recompress
+++ b/recompress
@@ -109,7 +109,7 @@ for i in $FILES; do
       echo "Compressed $FILE to $NEWFILE"
     fi
     cd $SRC_DIR
-    rm -r $DIFF_TMPDIR
+    rm -rf $DIFF_TMPDIR
   else
     echo "Compressed $FILE to $NEWFILE"
   fi


### PR DESCRIPTION
When recompress is combined with tar_scm with scm set to "git" and package-meta
set to "yes", the tarball produced by tar_scm contains the .git directory,
which in turn contains lots of write-protected files. Not supplying the -f
option causes rm to ask - for each file - if it really should remove it.