### PR TITLE
Use at least 2 threads for xz compression

### DIFF
--- a/recompress
+++ b/recompress
@@ -85,7 +85,7 @@ for i in $FILES; do
     COMPRESS="bzip2 -c -"
     NEWFILE="${BASENAME#_service:}.bz2"
   elif [ "$MYCOMPRESSION" == "xz" ]; then
-    COMPRESS="xz --threads=0 -c -"
+    COMPRESS="xz --threads=$(n=$(nproc); [[ $n > 1 ]] || n=2; echo $n) -c -"
     NEWFILE="${BASENAME#_service:}.xz"
   elif [ "$MYCOMPRESSION" == "zstd" -o "$MYCOMPRESSION" == "zst" ]; then
     COMPRESS="zstd --threads=0 -c -"


### PR DESCRIPTION
PR #11 introduced compression depending on number of available CPUs,
but xz then produces different output on 1-core-VMs as seen with:
`for n in 2 3 ; do echo | taskset $n xz --threads=0 -c - | md5sum ; done`

See https://reproducible-builds.org/ for why this matters.

Edit: also discussing better solutions upstream: https://www.mail-archive.com/xz-devel@tukaani.org/msg00375.html