### PR TITLE
Change default compress level

### DIFF
--- a/recompress
+++ b/recompress
@@ -90,7 +90,7 @@ for i in $FILES; do
     COMPRESS="xz --threads=$(n=$(nproc); [[ $n > 1 ]] || n=2; echo $n) -c -"
     NEWFILE="${BASENAME#_service:}.xz"
   elif [ "$MYCOMPRESSION" == "zstd" -o "$MYCOMPRESSION" == "zst" ]; then
-    COMPRESS="zstd --rsyncable -15 --threads=0 -c -"
+    COMPRESS="zstd --rsyncable -19 --threads=0 -c -"
     NEWFILE="${BASENAME#_service:}.zst"
   elif [ "$MYCOMPRESSION" == "none" ]; then
     COMPRESS="cat -"


### PR DESCRIPTION
Set the default compress level from 15 to 19. On packages that are quite large, especially common in rust this makes a large difference is the size of the resulting source.

For example in Kanidm the difference between 15 to 19 is 69MB to 60MB. Due to OBS' limited bandwidth, it can be extremely slow to download these sources from OBS, so that 9MB saving results in downloads being 90s faster to complete.